### PR TITLE
Consistent docs and project structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,6 @@
 We follow [Semantic Versioning](http://semver.org/) as a way of measuring stability of an update. This
 means we will never make a backwards-incompatible change within a major version of the project.
 
-## 0.1.0
+## UNRELEASED
 
-- Initial release
+_Nothing yet..._

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, @global-owner1 and @global-owner2
+# will be requested for review when someone opens a pull request.
+*       @itsthejoker
+
+*.sh    @thelonelyghost
+test/*  @thelonelyghost

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/TranscribersOfReddit/ToR_OCR.png?label=ready&title=Ready)](http://waffle.io/TranscribersOfReddit/ToR_OCR)
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/TranscribersOfReddit/TranscribersOfReddit.svg?columns=all)](http://waffle.io/TranscribersOfReddit/TranscribersOfReddit)
 
 # Contributing
 
@@ -14,43 +14,59 @@ Do your best to check as many of these boxes as you can and everything will be f
 ## Issues
 
 Any bugs you find, features you want to request, or questions you have should go in the
-repository's [issues section](https://github.com/TranscribersOfReddit/ToR_Archivist/issues).
+repository's [issues section](https://github.com/TranscribersOfReddit/ToR_Flair/issues).
 Please, be kind and search through both open and closed issues to make sure your question
 or bug report hasn't already been posted and resolved.
 
 ## Development
 
-After checking out the repo, run `bin/run setup` to install native dependencies.
+Initial setup:
 
-To install this package locally, setup a virtualenv environment and run `pip install -e .`
-from the project root. To make sure you have everything setup correctly, run `bin/run test`
-and it _should_ pass entirely.
+```bash
+# Clone the repository
+$ git clone git@github.com:TranscribersOfReddit/ToR_Flair.git tor_flair
+$ cd ./tor_flair
 
-In case you get tired of prefixing `bin/` to the `run` script here, [Tim Pope's method](https://twitter.com/tpope/status/165631968996900865)
-of safely adding a script to your PATH is recommended.
+# Setup sandbox
+$ virtualenv --no-site-packages --python=python3 venv
+$ source ./venv/bin/activate
+
+# Install the project in "editable" mode
+$ pip install --process-dependency-links -e .[dev]
+```
+
+In case there are any tests, they would be run by calling `python setup.py test`.
 
 ## Testing
 
-This project has (some) automated test coverage, so be sure to check that tests are passing
-_before_ you begin development. Our emphasis is on stability here, so if tests aren't passing,
-that's a bug.
+This project is expected to have automated test coverage, so be sure to check that tests
+are passing _before_ you begin development. Our emphasis is on stability here, so if tests
+aren't passing, that's a bug.
 
 ### Stability
 
 As noted before, make sure tests are passing before starting. If you have difficulty getting
 to that stable, initial state, reach out by opening an issue (see [Issues](#Issues) above).
-This is considered a failing by the maintainers if instructions are less than absolutely
-clear. Any feedback is helpful here!
+This is considered a failure by the maintainers if instructions are less than absolutely
+clear. Feedback is very helpful here!
 
 ### Writing tests
 
-Tests are written using `pytest` because it allows for simple decorators to modify when to
-run certain tests and the output is much prettier than `unittest`. We invoke the full test
-suite by calling `bin/run test`.
+Tests are written using `pytest` for a variety of reasons. Some of which are:
 
-At the moment, the test suite should run quickly, but that won't always be the case. Running
+- easy assertions that an exception will be thrown and the message it contains
+- skipping some tests for stated reasons
+- marking some tests as expected to fail
+- colorized output compared to `unittest`
+
+We should be able to invoke the full test suite by calling either `python setup.py test` or
+`pytest` from the terminal.
+
+The test suite should run quickly at the moment, but that won't always be the case. Running
 individual tests with `pytest path/to/test/file.py` is also acceptable while actively
-developing. Please note: a pull request should always have a fully passing test suite.
+developing.
+
+> **NOTE:** a pull request should always have a fully passing test suite.
 
 ## Pull Requests
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 TranscribersOfReddit
+Copyright (c) 2017 Grafeas Group, Ltd.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: clean all test
+
+all: test clean
+	@true
+
+clean:
+	@# echo "Removing \`*.pyc', \`*.pyo', and \`__pycache__/'"
+	@find . -regex '.+/[^/]+\.py[co]$$' -delete
+	@find . -regex '.+/__pycache__$$' -exec rm -rf {} \; -prune
+
+test: clean
+	@python setup.py test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Stories in Ready](https://badge.waffle.io/TranscribersOfReddit/ToR_OCR.png?label=ready&title=Ready)](http://waffle.io/TranscribersOfReddit/ToR_OCR)
+[![Waffle.io - Columns and their card count](https://badge.waffle.io/TranscribersOfReddit/TranscribersOfReddit.svg?columns=all)](http://waffle.io/TranscribersOfReddit/TranscribersOfReddit)
 
 # Flair Moderator Bot - Transcribers Of Reddit
 
-This is the source code for the ToR Flair Moderator Helper (`/u/tor_flair_bot`). It forms one part of the team that assists in the running of /r/TranscribersOfReddit (ToR), which is privileged to have the incredibly important job of organizing crowd-sourced transcriptions of images, video, and audio.
+This is the source code for the ToR Flair Moderator Helper (`/u/tor_flair_bot`). It forms one part of [the team][tor-team] that assists in the running of /r/TranscribersOfReddit (ToR), which is privileged to have the incredibly important job of organizing crowd-sourced transcriptions of images, video, and audio.
 
 As a whole, the ToR bots are designed to be as light on local resources as they can be, though there are some external requirements.
 
@@ -14,17 +14,19 @@ As a whole, the ToR bots are designed to be as light on local resources as they 
 > contains information such as the useragents and certain secrets. It is built
 > for Python 3.6.
 
+[tor-team]: https://github.com/TranscribersOfReddit
+
 ## Installation
 
 ```
-$ git clone https://github.com/TranscribersOfReddit/ToR_Flair_Bot.git tor-flair
-$ pip install --process-dependency-links tor-flair/
+$ git clone https://github.com/TranscribersOfReddit/ToR_Flair.git tor_flair
+$ pip install --process-dependency-links tor_flair/
 ```
 
 OR
 
 ```
-$ pip install --process-dependency-links 'git+https://github.com/TranscribersOfReddit/ToR_Flair.git@master#egg=tor_flair'
+$ pip install --process-dependency-links 'git+https://github.com/TranscribersOfReddit/ToR_Flair.git@master#egg=tor_flair-0'
 ```
 
 ## High-level functionality


### PR DESCRIPTION
This is a multi-project set of PRs:

- TranscribersOfReddit/ToR_Flair#3
- TranscribersOfReddit/ToR_Archivist#2
- TranscribersOfReddit/tor_core#10
- TranscribersOfReddit/ToR_OCR#8
- TranscribersOfReddit/TranscribersOfReddit#62

All of these pull requests center around the same concept: updating documentation and tooling to be a unified front.

- waffle.io badges were used inconsistently
- some references to the repository A when repository B was the intended target
- messy dependency tracking
- license files varying between `LICENSE` and `LICENSE.txt`, referencing a copyright holder as `TranscribersOfReddit`, which is not a legal entity.
- ... and so on

This merges all of that into a set of clean instructions, descriptive... well, descriptions, and making as much use of setup.py as possible (instead of the split standard with requirements.txt).